### PR TITLE
Persist throttle/debounce arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-throttle",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Throttles/debounces handlers of a child element",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "homepage": "https://github.com/gmcquistin/react-throttle#readme",
   "devDependencies": {
     "babel-cli": "^6.4.5",
-    "babel-eslint": "^4.1.8",
     "babel-istanbul": "^0.6.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
@@ -38,8 +37,6 @@
     "chai": "^3.5.0",
     "codecov": "^1.0.1",
     "enzyme": "^1.5.0",
-    "eslint": "^1.10.3",
-    "eslint-plugin-react": "^3.16.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5",
     "react-addons-test-utils": "^0.14.7",

--- a/src/classes/processors/Debouncer.js
+++ b/src/classes/processors/Debouncer.js
@@ -1,6 +1,7 @@
 import Base from './Base'
-import _ from 'lodash'
+import debounce from './helpers/debounce';
+
 
 export default class Debouncer extends Base {
-  _wrapHandler = (fn) => _.debounce(fn, this.time);
+  _wrapHandler = (fn) => debounce(fn, this.time);
 }

--- a/src/classes/processors/Throttler.js
+++ b/src/classes/processors/Throttler.js
@@ -1,6 +1,6 @@
 import Base from './Base'
-import _ from 'lodash'
+import throttle from './helpers/throttle';
 
 export default class Throttler extends Base {
-  _wrapHandler = (fn) => _.throttle(fn, this.time);
+  _wrapHandler = (fn) => throttle(fn, this.time);
 }

--- a/src/classes/processors/helpers/debounce.js
+++ b/src/classes/processors/helpers/debounce.js
@@ -1,4 +1,6 @@
-export default debounce(func, wait, options) {
+import { toNumber, isObject, now, cloneDeep } from 'lodash';
+
+export default function debounce(func, wait, options) {
   var lastArgs,
       lastThis,
       result,
@@ -15,7 +17,7 @@ export default debounce(func, wait, options) {
   wait = toNumber(wait) || 0;
   if (isObject(options)) {
     leading = !!options.leading;
-    maxWait = 'maxWait' in options && nativeMax(toNumber(options.maxWait) || 0, wait);
+    maxWait = 'maxWait' in options && Math.max(toNumber(options.maxWait) || 0, wait);
     trailing = 'trailing' in options ? !!options.trailing : trailing;
   }
 
@@ -95,8 +97,7 @@ export default debounce(func, wait, options) {
     var time = now(),
         isInvoking = shouldInvoke(time);
 
-    lastArgs = arguments;
-    console.log('args', lastArgs);
+    lastArgs = cloneDeep(Array.prototype.slice.call(arguments));
     lastThis = this;
     lastCallTime = time;
 

--- a/src/classes/processors/helpers/debounce.js
+++ b/src/classes/processors/helpers/debounce.js
@@ -1,0 +1,117 @@
+export default debounce(func, wait, options) {
+  var lastArgs,
+      lastThis,
+      result,
+      timerId,
+      lastCallTime = 0,
+      lastInvokeTime = 0,
+      leading = false,
+      maxWait = false,
+      trailing = true;
+
+  if (typeof func != 'function') {
+    throw new TypeError(FUNC_ERROR_TEXT);
+  }
+  wait = toNumber(wait) || 0;
+  if (isObject(options)) {
+    leading = !!options.leading;
+    maxWait = 'maxWait' in options && nativeMax(toNumber(options.maxWait) || 0, wait);
+    trailing = 'trailing' in options ? !!options.trailing : trailing;
+  }
+
+  function invokeFunc(time) {
+    var args = lastArgs,
+        thisArg = lastThis;
+
+    lastArgs = lastThis = undefined;
+    lastInvokeTime = time;
+    result = func.apply(thisArg, args);
+    return result;
+  }
+
+  function leadingEdge(time) {
+    // Reset any `maxWait` timer.
+    lastInvokeTime = time;
+    // Start the timer for the trailing edge.
+    timerId = setTimeout(timerExpired, wait);
+    // Invoke the leading edge.
+    return leading ? invokeFunc(time) : result;
+  }
+
+  function remainingWait(time) {
+    var timeSinceLastCall = time - lastCallTime,
+        timeSinceLastInvoke = time - lastInvokeTime,
+        result = wait - timeSinceLastCall;
+
+    return maxWait === false ? result : nativeMin(result, maxWait - timeSinceLastInvoke);
+  }
+
+  function shouldInvoke(time) {
+    var timeSinceLastCall = time - lastCallTime,
+        timeSinceLastInvoke = time - lastInvokeTime;
+
+    // Either this is the first call, activity has stopped and we're at the
+    // trailing edge, the system time has gone backwards and we're treating
+    // it as the trailing edge, or we've hit the `maxWait` limit.
+    return (!lastCallTime || (timeSinceLastCall >= wait) ||
+      (timeSinceLastCall < 0) || (maxWait !== false && timeSinceLastInvoke >= maxWait));
+  }
+
+  function timerExpired() {
+    var time = now();
+    if (shouldInvoke(time)) {
+      return trailingEdge(time);
+    }
+    // Restart the timer.
+    timerId = setTimeout(timerExpired, remainingWait(time));
+  }
+
+  function trailingEdge(time) {
+    clearTimeout(timerId);
+    timerId = undefined;
+
+    // Only invoke if we have `lastArgs` which means `func` has been
+    // debounced at least once.
+    if (trailing && lastArgs) {
+      return invokeFunc(time);
+    }
+    lastArgs = lastThis = undefined;
+    return result;
+  }
+
+  function cancel() {
+    if (timerId !== undefined) {
+      clearTimeout(timerId);
+    }
+    lastCallTime = lastInvokeTime = 0;
+    lastArgs = lastThis = timerId = undefined;
+  }
+
+  function flush() {
+    return timerId === undefined ? result : trailingEdge(now());
+  }
+
+  function debounced() {
+    var time = now(),
+        isInvoking = shouldInvoke(time);
+
+    lastArgs = arguments;
+    console.log('args', lastArgs);
+    lastThis = this;
+    lastCallTime = time;
+
+    if (isInvoking) {
+      if (timerId === undefined) {
+        return leadingEdge(lastCallTime);
+      }
+      // Handle invocations in a tight loop.
+      clearTimeout(timerId);
+      timerId = setTimeout(timerExpired, wait);
+      return invokeFunc(lastCallTime);
+    }
+    return result;
+  }
+  debounced.cancel = cancel;
+  debounced.flush = flush;
+  return debounced;
+}

--- a/src/classes/processors/helpers/throttle.js
+++ b/src/classes/processors/helpers/throttle.js
@@ -1,0 +1,20 @@
+import { isObject } from 'lodash';
+import debounce from './debounce';
+
+export default function throttle(func, wait, options) {
+  var leading = true,
+      trailing = true;
+
+  if (typeof func != 'function') {
+    throw new TypeError(FUNC_ERROR_TEXT);
+  }
+  if (isObject(options)) {
+    leading = 'leading' in options ? !!options.leading : leading;
+    trailing = 'trailing' in options ? !!options.trailing : trailing;
+  }
+  return debounce(func, wait, {
+    'leading': leading,
+    'maxWait': wait,
+    'trailing': trailing
+  });
+}


### PR DESCRIPTION
Resolves #2.

I have copied `throttle` and `debounce` from the Lodash library and added a line which clones the arguments, so the debounced function will receive a clone of the original arguments. In this way, even if the original caller modifies the arguments after the fact, we will still have a copy.
