### PR TITLE
Use lodash includes function

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,17 +30,17 @@
   "homepage": "https://github.com/gmcquistin/react-throttle#readme",
   "devDependencies": {
     "babel-cli": "^6.4.5",
-    "babel-istanbul": "^0.6.0",
+    "babel-istanbul": "^0.11.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
     "chai": "^3.5.0",
     "codecov": "^1.0.1",
-    "enzyme": "^1.5.0",
+    "enzyme": "^2.4.1",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
-    "react-addons-test-utils": "^0.14.7",
-    "react-dom": "^0.14.7",
+    "mocha": "^3.0.2",
+    "react-addons-test-utils": "^15.3.1",
+    "react-dom": "^15.3.1",
     "sinon": "^1.17.3",
     "snyk": "^1.9.1"
   },
@@ -48,7 +48,7 @@
     "enzyme": "^2.3.0",
     "lodash": "^4.2.1",
     "react": "^15.0.2",
-    "react-addons-test-utils": "^15.0.2",
-    "react-dom": "^15.0.2"
+    "react-addons-test-utils": "^15.3.1",
+    "react-dom": "^15.3.1"
   }
 }

--- a/src/classes/processors/Base.js
+++ b/src/classes/processors/Base.js
@@ -41,7 +41,7 @@ export default class Base {
   _wrapHandlers = () => _.mapValues(this._extractHandlers(), this._wrapHandler);
 
   _shouldWrapHandler = (handler, handlerName) => {
-    return _.isFunction(handler) && this.time > 0 && this.handlersToWrap.includes(handlerName);
+    return _.isFunction(handler) && this.time > 0 && _.includes(this.handlersToWrap, handlerName);
   };
 
   // Cancel timers related to throttling


### PR DESCRIPTION
- Older browsers do not have `Array.prototype.includes` and since we are already bringing in lodash, this makes more sense then a polyfill.
