### PR TITLE
Use `babel-plugin-lodash`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "stage-0", "react"]
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": ["lodash"]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Throttles/debounces handlers of a child element",
   "main": "lib/index.js",
   "scripts": {
-    "compile": "rm -rf lib && babel --presets es2015,stage-0,react -d lib/ src/",
+    "compile": "rm -rf lib && babel -d lib/ src/",
     "prepublish": "npm run compile",
     "test": "snyk test && npm run compile && NODE_ENV=test mocha --compilers js:babel-register --require babel-polyfill --require jsdom-global/register --require test/setup.js --recursive",
     "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover _mocha -- --compilers js:babel-register --require babel-polyfill --recursive"
@@ -31,6 +31,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-istanbul": "^0.12.2",
+    "babel-plugin-lodash": "^3.3.2",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",

--- a/src/classes/processors/Base.js
+++ b/src/classes/processors/Base.js
@@ -1,7 +1,5 @@
 import React from 'react';
-import lodash from 'lodash';
-
-const _ = lodash.runInContext();
+import _ from 'lodash';
 
 // Processes a ReactElement by iterating over its props, looking for
 // props which are specified by `handlersToWrap`. Matching props will


### PR DESCRIPTION
This patch introduces the `babel-plugin-lodash` plugin in order to rewrite the `lodash` imports from, say:

``` js
import _ from 'lodash';

export default function(func) {
    return _.isFunction(func) && func.name === 'debounced';
}
```

to:

``` js
import isFunction from 'lodash/isFunction';

export default function(func) {
    return isFunction(func) && func.name === 'debounced';
}
```

This helps to reduce bundle size. Bundle size before patch:

``` bash
$ browserify lib | gzip -9 | wc -c | pretty-bytes
132 kB
```

Bundle size with this patch:

``` bash
$ browserify lib | gzip -9 | wc -c | pretty-bytes
62.9 kB
```

Fixes https://github.com/gmcquistin/react-throttle/issues/5