### PR TITLE
Register jsdom-global on test to fix debouncer test failing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "compile": "rm -rf lib && babel --presets es2015,stage-0,react -d lib/ src/",
     "prepublish": "npm run compile",
-    "test": "snyk test && npm run compile && NODE_ENV=test mocha --compilers js:babel-register --require babel-polyfill --recursive",
+    "test": "snyk test && npm run compile && NODE_ENV=test mocha --compilers js:babel-register --require babel-polyfill --require jsdom-global/register --recursive",
     "coverage": "./node_modules/.bin/babel-node ./node_modules/.bin/babel-istanbul cover _mocha -- --compilers js:babel-register --require babel-polyfill --recursive"
   },
   "repository": {
@@ -38,6 +38,8 @@
     "codecov": "^1.0.1",
     "enzyme": "^2.4.1",
     "istanbul": "^0.4.2",
+    "jsdom": "^11.3.0",
+    "jsdom-global": "^3.0.2",
     "mocha": "^3.0.2",
     "react-addons-test-utils": "^15.3.1",
     "react-dom": "^15.3.1",


### PR DESCRIPTION
This PR will fix the failure of the following test:

```
% npm test

> react-throttle@0.3.0 test /Users/taiki/src/github.com/gmcquistin/react-throttle
> snyk test && npm run compile && NODE_ENV=test mocha --compilers js:babel-register --require babel-polyfill --recursive

✓ Tested 72 dependencies for known vulnerabilities, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.


> react-throttle@0.3.0 compile /Users/taiki/src/github.com/gmcquistin/react-throttle
> rm -rf lib && babel --presets es2015,stage-0,react -d lib/ src/

src/classes/processors/Base.js -> lib/classes/processors/Base.js
src/classes/processors/Debouncer.js -> lib/classes/processors/Debouncer.js
src/classes/processors/Throttler.js -> lib/classes/processors/Throttler.js
src/classes/processors/helpers/debounce.js -> lib/classes/processors/helpers/debounce.js
src/classes/processors/helpers/throttle.js -> lib/classes/processors/helpers/throttle.js
src/components/Base.js -> lib/components/Base.js
src/components/Debounce.js -> lib/components/Debounce.js
src/components/Throttle.js -> lib/components/Throttle.js
src/index.js -> lib/index.js
[enzyme/withDom] Error: missing required module "jsdom"
[enzyme/withDom] To fix this you must run:
[enzyme/withDom]   npm install jsdom --save-dev
Warning: ReactTestUtils has been moved to react-dom/test-utils. Update references to remove this warning.


  Debouncer component
Warning: Shallow renderer has been moved to react-test-renderer/shallow. Update references to remove this warning.
    ✓ should render the child component
    with one prop to wrap
      ✓ should wrap specified prop
      ✓ should not wrap unspecified prop
    with an array of props to wrap
      ✓ should wrap specified props
      ✓ should not wrap unspecified props
    when unmounting
      1) should cancel throttling operations

  Base processor
    ✓ should not be directly instantiable
    ✓ should cancel throttle functions when destroyed (409ms)
    ✓ should wrap functions properly (256ms)

  Debounce processor
    ✓ should wrap handlers with debounce function

  Debounce processor
    ✓ should wrap handlers with throttler function


  10 passing (724ms)
  1 failing

  1) Debouncer component when unmounting should cancel throttling operations:
     Error: It looks like you called `mount()` without a global document being loaded.
      at new ReactWrapper (node_modules/enzyme/build/ReactWrapper.js:89:13)
      at mount (node_modules/enzyme/build/mount.js:19:10)
      at Context.<anonymous> (test/unit/components/debouncer.js:79:23)



npm ERR! Test failed.  See above for more details.
```